### PR TITLE
finishes number doubling route

### DIFF
--- a/part-1/server.js
+++ b/part-1/server.js
@@ -19,6 +19,11 @@ app.get('/subtract', (request, response) => {
   response.send(subtractNumbers.toString())
 })
 
+app.get('/double/:number', (request, response) => {
+  let doubleNumber = parseInt(request.params.number) * 2
+  response.send(doubleNumber.toString())
+})
+
 app.listen(3000, () => {
   console.log('Express Server started on port 3000')
 })


### PR DESCRIPTION
double number route works: it takes a string, converts to number, doubles the number, then converts back to a string. tried using query at first and realized this would not work (returns NaN), using request.params to grab the string from the url request. 